### PR TITLE
Require trailing comma in functions

### DIFF
--- a/src/phpcs.xml
+++ b/src/phpcs.xml
@@ -125,6 +125,9 @@
             <property name="spacesCountAfterKeyword" value="0"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 
     <!-- Namespaces -->
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>


### PR DESCRIPTION
https://app.shortcut.com/goi/story/9162