### PR TITLE
Exclude MissingNamespace rule from database/migrations/.

### DIFF
--- a/src/phpcs.xml
+++ b/src/phpcs.xml
@@ -8,6 +8,10 @@
     <!-- Custom rules -->
     <config name="installed_paths" value="vendor/slevomat/coding-standard"/>
 
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>./database/migrations/*</exclude-pattern>
+    </rule>
+
     <rule ref="PSR1.Methods.CamelCapsMethodName">
         <exclude-pattern>./tests/*</exclude-pattern>
     </rule>


### PR DESCRIPTION
https://app.shortcut.com/goi/story/3952