### PR TITLE
Disallow spacing before assignments.

### DIFF
--- a/src/phpcs.xml
+++ b/src/phpcs.xml
@@ -152,6 +152,12 @@
 
     <!-- Operators -->
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true" />
+            <property name="ignoreSpacingBeforeAssignments" value="false" />
+        </properties>
+    </rule>
 
     <!-- PHP -->
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>


### PR DESCRIPTION
This PR adds the rule Squiz.WhiteSpace.OperatorSpacing to avoid extra spacing before and after operators.

New lines are allowed.